### PR TITLE
feat: default db_type to auto-detect when omitted

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,8 +25,11 @@ cargo build --bin sig2yar
 ## 使い方
 
 ```bash
-sig2yar <db_type> <signature>
+sig2yar [db_type] <signature>
 ```
+
+`db_type` を省略した場合は、署名構文から自動判定する。
+自動判定が曖昧な場合は `db_type` を明示指定する。
 
 `db_type` は ClamAV DB ファミリ名の互換aliasも受け付ける。
 
@@ -49,6 +52,12 @@ sig2yar hash "44d88612fea8a8f36de82e1278abb02f:68:Eicar-Test-Signature"
 
 ```bash
 sig2yar logical "Foo.Bar-1;Engine:51-255,Target:1;0;41424344"
+```
+
+例（自動判定、db_type省略）:
+
+```bash
+sig2yar "Foo.Bar-1;Engine:51-255,Target:1;0;41424344"
 ```
 
 例（`logical` + best-effort 非strictモード）:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ cargo build --bin sig2yar
 ## Usage
 
 ```bash
-sig2yar <db_type> <signature>
+sig2yar [db_type] <signature>
 ```
+
+If `db_type` is omitted, sig2yar tries auto-detection from signature syntax.
+When auto-detection is ambiguous, pass `db_type` explicitly.
 
 `db_type` accepts compatibility aliases by ClamAV DB family as well:
 
@@ -49,6 +52,12 @@ Example (`logical`):
 
 ```bash
 sig2yar logical "Foo.Bar-1;Engine:51-255,Target:1;0;41424344"
+```
+
+Example (`auto-detect`, db_type omitted):
+
+```bash
+sig2yar "Foo.Bar-1;Engine:51-255,Target:1;0;41424344"
 ```
 
 Example (`logical` + best-effort non-strict mode):


### PR DESCRIPTION
## Summary
Make `db_type` optional in CLI usage and default to auto-detection when omitted.

- Usage becomes: `sig2yar [db_type] <signature>`
- Existing explicit form remains supported: `sig2yar logical '<sig>'`

## Behavior
- If two positional args are provided:
  - first is treated as explicit `db_type`
  - second is signature
- If one positional arg is provided:
  - treated as signature
  - `db_type` is auto-detected

## Auto-detection policy (conservative)
Auto mode now prefers high-confidence families to avoid ambiguity from broad parsers:
- logical (if `;`-based logical parse succeeds)
- hash
- ndb
- ndu
- idb
- imp
- info (only `ClamAV-VDB:`/`DSIG:` prefixed lines)
- cbc (multiline payload only)

If no confident match is found, returns:
- `failed to auto-detect db_type from signature; pass explicit db_type`

## Why this policy
Some parsers are intentionally broad (`cbc`, `info`, `ldu`), so naive probe-all matching caused frequent ambiguity in real logical signatures.
This keeps default auto mode practical while preserving explicit override for edge families.

## Tests
- args resolution tests added:
  - auto mode when db_type omitted
  - explicit aliases still resolve (`ldb`, `hdb/hsb/mdb/msb`)
  - invalid explicit db_type fails during resolve
- render test added:
  - omitted db_type auto-detects logical signature

## Docs
- README (EN/JA) updated to show optional `db_type` and auto-detect examples.

## Validation
- `cargo test --locked --test yara_rule --test yara_compile`
- `cargo test --locked --all-targets`
